### PR TITLE
Add option to customize the skrim color

### DIFF
--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -36,6 +36,7 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
     this.triggerMode,
     this.barrierDismissible = true,
     this.barrierColor = Colors.transparent,
+    this.barrierBuilder,
     this.enableFeedback,
     this.hoverShowDuration,
     this.fadeInDuration = const Duration(milliseconds: 150),
@@ -94,6 +95,9 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
 
   @override
   final bool? enableFeedback;
+
+  @override
+  final Widget Function(BuildContext, VoidCallback)? barrierBuilder;
 
   // FIXME: This happens in the non-hover (i.e. isModal) case as well.
   @override
@@ -314,6 +318,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
   late bool enableFeedback;
   late bool barrierDismissible;
   late Color barrierColor;
+  late Widget Function(BuildContext, VoidCallback)? barrierBuilder;
 
   // These properties are specific to just_the_tooltip
   // static const Curve _defaultAnimateCurve = Curves.linear;
@@ -599,6 +604,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
         _defaultEnableFeedback;
     barrierDismissible = widget.barrierDismissible;
     barrierColor = widget.barrierColor;
+    barrierBuilder = widget.barrierBuilder;
 
     Widget result = GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -631,6 +637,12 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
   }
 
   Widget _createSkrim() {
+    if (barrierBuilder != null) {
+      return Container(
+        key: skrimKey,
+        child: barrierBuilder!(context, _hideTooltip),
+      );
+    }
     return GestureDetector(
       key: skrimKey,
       behavior: barrierDismissible

--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -35,6 +35,7 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
     this.showDuration,
     this.triggerMode,
     this.barrierDismissible = true,
+    this.barrierColor = Colors.transparent,
     this.enableFeedback,
     this.hoverShowDuration,
     this.fadeInDuration = const Duration(milliseconds: 150),
@@ -84,6 +85,9 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
 
   @override
   final bool barrierDismissible;
+
+  @override
+  final Color barrierColor;
 
   @override
   final TooltipTriggerMode? triggerMode;
@@ -309,6 +313,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
   late TooltipTriggerMode triggerMode;
   late bool enableFeedback;
   late bool barrierDismissible;
+  late Color barrierColor;
 
   // These properties are specific to just_the_tooltip
   // static const Curve _defaultAnimateCurve = Curves.linear;
@@ -593,6 +598,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
         tooltipTheme.enableFeedback ??
         _defaultEnableFeedback;
     barrierDismissible = widget.barrierDismissible;
+    barrierColor = widget.barrierColor;
 
     Widget result = GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -631,6 +637,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
           ? HitTestBehavior.translucent
           : HitTestBehavior.deferToChild,
       onTap: _hideTooltip,
+      child: Container(color: barrierColor),
     );
   }
 

--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -97,7 +97,8 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
   final bool? enableFeedback;
 
   @override
-  final Widget Function(BuildContext, VoidCallback)? barrierBuilder;
+  final Widget Function(BuildContext, Animation<double>, VoidCallback)?
+      barrierBuilder;
 
   // FIXME: This happens in the non-hover (i.e. isModal) case as well.
   @override
@@ -243,20 +244,20 @@ class _JustTheTooltipOverlayState extends _JustTheTooltipState<OverlayEntry> {
     }
   }
 
-  // @override
-  // void didUpdateWidget(covariant JustTheTooltip oldWidget) {
-  //   super.didUpdateWidget(oldWidget);
+// @override
+// void didUpdateWidget(covariant JustTheTooltip oldWidget) {
+//   super.didUpdateWidget(oldWidget);
 
-  //   // This adds a post frame callback because otherwise the OverlayEntry
-  //   // builder would run before the widget has a chance to update with the
-  //   // newest config.
-  //   WidgetsBinding.instance?.addPostFrameCallback((_) {
-  //     if (mounted) {
-  //       entry?.markNeedsBuild();
-  //       skrim?.markNeedsBuild();
-  //     }
-  //   });
-  // }
+//   // This adds a post frame callback because otherwise the OverlayEntry
+//   // builder would run before the widget has a chance to update with the
+//   // newest config.
+//   WidgetsBinding.instance?.addPostFrameCallback((_) {
+//     if (mounted) {
+//       entry?.markNeedsBuild();
+//       skrim?.markNeedsBuild();
+//     }
+//   });
+// }
 }
 
 /// This is almost a one to one mapping to [Tooltip]'s [_TooltipState] except
@@ -318,7 +319,8 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
   late bool enableFeedback;
   late bool barrierDismissible;
   late Color barrierColor;
-  late Widget Function(BuildContext, VoidCallback)? barrierBuilder;
+  late Widget Function(BuildContext, Animation<double>, VoidCallback)?
+      barrierBuilder;
 
   // These properties are specific to just_the_tooltip
   // static const Curve _defaultAnimateCurve = Curves.linear;
@@ -640,7 +642,7 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
     if (barrierBuilder != null) {
       return Container(
         key: skrimKey,
-        child: barrierBuilder!(context, _hideTooltip),
+        child: barrierBuilder!(context, _animationController, _hideTooltip),
       );
     }
     return GestureDetector(

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -18,6 +18,7 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
     this.showDuration,
     this.triggerMode,
     this.barrierDismissible = true,
+    this.barrierColor = Colors.transparent,
     this.enableFeedback,
     this.hoverShowDuration,
     this.fadeInDuration = const Duration(milliseconds: 150),
@@ -70,6 +71,9 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
 
   @override
   final bool barrierDismissible;
+
+  @override
+  final Color barrierColor;
 
   @override
   final bool? enableFeedback;

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -77,7 +77,8 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
   final Color barrierColor;
 
   @override
-  final Widget Function(BuildContext, VoidCallback)? barrierBuilder;
+  final Widget Function(BuildContext, Animation<double>, VoidCallback)?
+      barrierBuilder;
 
   @override
   final bool? enableFeedback;

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -19,6 +19,7 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
     this.triggerMode,
     this.barrierDismissible = true,
     this.barrierColor = Colors.transparent,
+    this.barrierBuilder,
     this.enableFeedback,
     this.hoverShowDuration,
     this.fadeInDuration = const Duration(milliseconds: 150),
@@ -74,6 +75,9 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
 
   @override
   final Color barrierColor;
+
+  @override
+  final Widget Function(BuildContext, VoidCallback)? barrierBuilder;
 
   @override
   final bool? enableFeedback;

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -164,7 +164,8 @@ abstract class JustTheInterface extends StatefulWidget {
   ///
   /// If barrier builder is null, a default barrier is built according to
   /// [barrierColor] and [barrierDismissible].
-  Widget Function(BuildContext, VoidCallback)? get barrierBuilder;
+  Widget Function(BuildContext, Animation<double>, VoidCallback)?
+      get barrierBuilder;
 
   /// Whether the tooltip should provide acoustic and/or haptic feedback.
   ///

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -139,6 +139,11 @@ abstract class JustTheInterface extends StatefulWidget {
   /// by using [controller.hideTooltip].
   bool get barrierDismissible;
 
+  /// The color to display between the tooltip and widgets behind the tooltip.
+  ///
+  /// Defaults to [Colors.transparent].
+  Color get barrierColor;
+
   /// Whether the tooltip should provide acoustic and/or haptic feedback.
   ///
   /// For example, on Android a tap will produce a clicking sound and a

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -139,10 +139,32 @@ abstract class JustTheInterface extends StatefulWidget {
   /// by using [controller.hideTooltip].
   bool get barrierDismissible;
 
-  /// The color to display between the tooltip and widgets behind the tooltip.
+  /// A widget to be displayed between the tooltip and app's content.
   ///
   /// Defaults to [Colors.transparent].
+  ///
+  /// If [barrierBuilder] is non-null, barrier color will be ignored.
   Color get barrierColor;
+
+  /// A widget to be displayed between the tooltip and app's content.
+  ///
+  /// The barrier builder can call the provided void callback to dismiss the
+  /// tooltip.
+  ///
+  /// This is most often a tapable container with a semi-opaque color:
+  ///
+  /// ```
+  ///   barrierBuilder: (context, dismissTooltip) {
+  ///     return GestureDetector(
+  ///       onTap: dismissTooltip,
+  ///       child: Container(color: Colors.black38), // black38 has 38% opacity
+  ///     );
+  ///   },
+  /// ```
+  ///
+  /// If barrier builder is null, a default barrier is built according to
+  /// [barrierColor] and [barrierDismissible].
+  Widget Function(BuildContext, VoidCallback)? get barrierBuilder;
 
   /// Whether the tooltip should provide acoustic and/or haptic feedback.
   ///


### PR DESCRIPTION
It'd nice to be able to partially obscure the content behind the tooltip to communicate that tapping outside the tooltip will dismiss the tooltip.

Ideally, we'd also provide the option to not obscure the child widget with the colored skrim-but I honestly have no idea how to do that. We'd have to get the outline of the child widget and use it as a clip path on the skrim.

Leaving it to you to bump the version numbers and changelog should you accept this PR.