### PR TITLE
Make callbacks fire before future

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,3 +1,4 @@
 **/test/goldens
 **/test/failures
 example/
+screenshots/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/pages/animated_barrier_page.dart';
 import 'package:example/pages/default_page.dart';
 import 'package:example/pages/scroll_page.dart';
 import 'package:example/pages/tooltip_area_page.dart';
@@ -31,6 +32,12 @@ class MyApp extends StatelessWidget {
             return MaterialPageRoute<void>(
               settings: settings,
               builder: (BuildContext context) => const TooltipAreaExamplePage(),
+            );
+          case 'animatedBarrier':
+            return MaterialPageRoute<void>(
+              settings: settings,
+              builder: (BuildContext context) =>
+                  const AnimatedBarrierExamplePage(),
             );
           default:
             throw UnimplementedError();
@@ -72,6 +79,13 @@ class HomePage extends StatelessWidget {
                 Navigator.of(context).pushNamed('tooltipArea');
               },
               child: const Text('tooltipArea'),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(primary: Colors.brown),
+              onPressed: () {
+                Navigator.of(context).pushNamed('animatedBarrier');
+              },
+              child: const Text('animatedBarrier'),
             ),
           ],
         ),

--- a/example/lib/pages/animated_barrier_page.dart
+++ b/example/lib/pages/animated_barrier_page.dart
@@ -26,10 +26,8 @@ class _AnimatedBarrierExamplePageState
       tooltipController.showTooltip(immediately: false);
     });
 
-    print('----');
-    print(tooltipController.value);
     tooltipController.addListener(() {
-      print('controller: ${tooltipController.value}');
+      // print('controller: ${tooltipController.value}');
     });
     super.initState();
   }
@@ -87,22 +85,22 @@ class _AnimatedBarrierExamplePageState
               child: JustTheTooltip(
                 onShow: (showAnimation) {
                   setState(() {
-                    print('Showing tooltip!');
+                    // print('Showing tooltip!');
                     _animation = showAnimation;
                     _animation.addStatusListener((status) {
                       if (status == AnimationStatus.completed) {
-                        print('Tooltip shown!');
+                        // print('Tooltip shown!');
                       }
                     });
                   });
                 },
                 onDismiss: (dismissAnimation) {
-                  print('Dismissing tooltip!');
+                  // print('Dismissing tooltip!');
                   setState(() {
                     _animation = dismissAnimation;
                     _animation.addStatusListener((status) {
                       if (status == AnimationStatus.dismissed) {
-                        print('Tooltip dismissed!');
+                        // print('Tooltip dismissed!');
                       }
                     });
                   });

--- a/example/lib/pages/animated_barrier_page.dart
+++ b/example/lib/pages/animated_barrier_page.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:just_the_tooltip/just_the_tooltip.dart';
+
+import 'dart:math' as math;
+
+class AnimatedBarrierExamplePage extends StatefulWidget {
+  const AnimatedBarrierExamplePage({Key? key}) : super(key: key);
+
+  @override
+  State<AnimatedBarrierExamplePage> createState() =>
+      _AnimatedBarrierExamplePageState();
+}
+
+class _AnimatedBarrierExamplePageState
+    extends State<AnimatedBarrierExamplePage> {
+  final tooltipController = JustTheController();
+  var length = 10.0;
+  var color = Colors.pink;
+  var alignment = Alignment.center;
+
+  Animation<double> _animation = kAlwaysDismissedAnimation;
+
+  @override
+  void initState() {
+    Future.delayed(const Duration(seconds: 2), () {
+      tooltipController.showTooltip(immediately: false);
+    });
+
+    print('----');
+    print(tooltipController.value);
+    tooltipController.addListener(() {
+      print('controller: ${tooltipController.value}');
+    });
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const margin = EdgeInsets.all(16.0);
+
+    return Scaffold(
+      appBar: AppBar(),
+      floatingActionButton: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          ElevatedButton(
+            child: const Icon(Icons.add),
+            onPressed: () {
+              tooltipController.showTooltip(immediately: true);
+            },
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            child: const Icon(Icons.remove),
+            onPressed: () {
+              tooltipController.hideTooltip(immediately: true);
+            },
+          ),
+        ],
+      ),
+      body: SizedBox.expand(
+        child: Stack(
+          children: [
+            LayoutBuilder(builder: (context, constraints) {
+              // Use the pythagorean theorem to get the diameter of the circle
+              // that circumscribes the constraints.
+              final double diameter = math.sqrt(
+                      math.pow(constraints.maxHeight, 2) +
+                          math.pow(constraints.maxWidth, 2));
+              return ScaleTransition(
+                scale: Tween<double>(begin: 0, end: 1).animate(_animation),
+                child: OverflowBox(
+                  maxWidth: diameter,
+                  maxHeight: diameter,
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      color: Colors.white30,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              );
+            }),
+            AnimatedAlign(
+              duration: const Duration(milliseconds: 1500),
+              alignment: alignment,
+              child: JustTheTooltip(
+                onShow: (showAnimation) {
+                  setState(() {
+                    print('Showing tooltip!');
+                    _animation = showAnimation;
+                    _animation.addStatusListener((status) {
+                      if (status == AnimationStatus.completed) {
+                        print('Tooltip shown!');
+                      }
+                    });
+                  });
+                },
+                onDismiss: (dismissAnimation) {
+                  print('Dismissing tooltip!');
+                  setState(() {
+                    _animation = dismissAnimation;
+                    _animation.addStatusListener((status) {
+                      if (status == AnimationStatus.dismissed) {
+                        print('Tooltip dismissed!');
+                      }
+                    });
+                  });
+                },
+                backgroundColor: color,
+                controller: tooltipController,
+                tailLength: length,
+                tailBaseWidth: 20.0,
+                isModal: true,
+                preferredDirection: AxisDirection.up,
+                margin: margin,
+                borderRadius: BorderRadius.circular(8.0),
+                offset: 0,
+                child: Material(
+                  color: Colors.grey.shade800,
+                  shape: const CircleBorder(),
+                  elevation: 4.0,
+                  child: const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Icon(
+                      Icons.add,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+                content: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 200.0),
+                    child: const Text(
+                      'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/default_page.dart
+++ b/example/lib/pages/default_page.dart
@@ -55,10 +55,10 @@ class _DefaultPageExampleState extends State<DefaultPageExample> {
           duration: const Duration(milliseconds: 1500),
           alignment: alignment,
           child: JustTheTooltip(
-            onShow: () {
+            onShow: (showAnimation) {
               // print('onShow');
             },
-            onDismiss: () {
+            onDismiss: (dismissAnimation) {
               // print('onDismiss');
             },
             backgroundColor: color,

--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -432,12 +432,12 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
   /// this future will complete once the tooltip has been completely hidden.
   Future<void> _hideTooltip({bool immediately = false}) async {
     cancelShowTimer();
+    widget.onDismiss?.call();
 
     final completer = Completer<void>();
     final future = completer.future;
 
     if (immediately) {
-      widget.onDismiss?.call();
 
       if (mounted) {
         _controller.value = TooltipStatus.isHidden;
@@ -477,10 +477,10 @@ abstract class _JustTheTooltipState<T> extends State<JustTheInterface>
     bool autoClose = false,
   }) async {
     cancelHideTimer();
+    widget.onShow?.call();
 
     final completer = Completer<void>();
     final future = completer.future.then((_) {
-      widget.onShow?.call();
 
       if (mounted) {
         _controller.value = TooltipStatus.isShowing;

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -51,10 +51,10 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
   final Widget child;
 
   @override
-  final VoidCallback? onDismiss;
+  final void Function(Animation<double>)? onDismiss;
 
   @override
-  final VoidCallback? onShow;
+  final void Function(Animation<double>)? onShow;
 
   @override
   final bool isModal;

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -95,12 +95,48 @@ abstract class JustTheInterface extends StatefulWidget {
   /// in the `isModal` is false case.
   Widget get child;
 
-  /// Called when the tooltip is dismissed either by waiting the specified
-  /// [duration] or by tapping on the scrim.
-  VoidCallback? get onDismiss;
 
-  /// Called when the tooltip is shown.
-  VoidCallback? get onShow;
+  /// Called when the tooltip begins animating out because it was dismissed
+  /// either by waiting for [waitDuration] to expire, tapping a dismissible
+  /// barrier, or calling [JustTheController.defaultHideTooltip].
+  ///
+  /// The animation used to dismiss the tooltip is passed in to `onDismiss`. It
+  /// animates from 1 to 0.
+  ///
+  /// To execute a callback when the tooltip has finished animating, use a
+  /// status listener on the animation:
+  ///
+  /// ```
+  ///   onDismiss: (animation) {
+  ///     animation.addStatusListener((status) {
+  ///       print('Dismissing tooltip!');
+  ///       if (status == AnimationStatus.dismissed) {
+  ///         print('Tooltip dismissed!');
+  ///       }
+  ///     });
+  ///   },
+  /// ```
+  void Function(Animation<double>)? get onDismiss;
+
+  /// Called when the tooltip begins animating in.
+  ///
+  /// The animation used to show the tooltip is passed in to `onShow`. It
+  /// animates from 0 to 1.
+  ///
+  /// To execute a callback when the tooltip has finished animating, use a
+  /// status listener on the animation:
+  ///
+  /// ```
+  ///   onShow: (animation) {
+  ///     animation.addStatusListener((status) {
+  ///       print('Showing tooltip!');
+  ///       if (status == AnimationStatus.completed) {
+  ///         print('Tooltip shown!');
+  ///       }
+  ///     });
+  ///   },
+  /// ```
+  void Function(Animation<double>)? get onShow;
 
   /// If true, once the tooltip is opened, it will not close after a set
   /// duration. It will instead instead stay on the screen until either the


### PR DESCRIPTION
Currently, the `onShow` and the `onDismiss`  callbacks fire when their respective actions are completed, not when the actions start. This PR makes them fire on start.

This is preferable because developers often want to trigger behavior on start (eg to play an animation in-step with the tooltip's show animation). They can't do this with the current design because their callback runs too late.

If developers want to trigger behavior when the tooltip animations finish, they can simply add a delay of the same duration as their animations to their callback:

```dart
  onShow: () async {
    await Future.delayed(milliseconds: 150);
    doStuffAfterToolTipIsShown();
  }
```