### PR TITLE
Add clickable area

### DIFF
--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -26,6 +26,7 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
     required this.child,
     this.onDismiss,
     this.onShow,
+    this.onClick,
     this.controller,
     // TODO: With the new [triggerMode] field isModal's only function is to keep
     // the tooltip open. But in that case, it seems like we can create a new
@@ -73,6 +74,9 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
 
   @override
   final VoidCallback? onShow;
+
+  @override
+  final VoidCallback? onClick;
 
   @override
   final bool isModal;
@@ -321,6 +325,7 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
   late JustTheController _controller;
   late bool _hasBindingListeners = false;
   final _layerLink = LayerLink();
+  final _tooltipContentKey = GlobalKey();
 
   @override
   void initState() {
@@ -531,6 +536,22 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
       return;
     }
 
+    if (widget.onClick != null) {
+      final box =
+          _tooltipContentKey.currentContext?.findRenderObject() as RenderBox?;
+
+      if (box != null) {
+        final targetSize = box.size;
+        final target = box.localToGlobal(Offset.zero);
+        final targetRect = Rect.fromLTWH(
+            target.dx, target.dy, targetSize.width, targetSize.height);
+        if (targetRect.contains(event.position)) {
+          widget.onClick!();
+          return;
+        }
+      }
+    }
+
     if (widget.clickableArea != null &&
         widget.clickableArea!.contains(event.position)) {
       return;
@@ -684,6 +705,7 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
             builder: (context) {
               final scrollController = widget.scrollController;
               final wrappedChild = Material(
+                key: _tooltipContentKey,
                 type: MaterialType.transparency,
                 child: widget.content,
               );

--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -541,11 +541,11 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
           _tooltipContentKey.currentContext?.findRenderObject() as RenderBox?;
 
       if (box != null) {
-        final targetSize = box.size;
-        final target = box.localToGlobal(Offset.zero);
-        final targetRect = Rect.fromLTWH(
-            target.dx, target.dy, targetSize.width, targetSize.height);
-        if (targetRect.contains(event.position)) {
+        final contentSize = box.size;
+        final contentPos = box.localToGlobal(Offset.zero);
+        final contentRect = Rect.fromLTWH(contentPos.dx, contentPos.dy,
+            contentSize.width, contentSize.height);
+        if (contentRect.contains(event.position)) {
           widget.onClick!();
           return;
         }

--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -56,6 +56,7 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
     this.shadow,
     this.showWhenUnlinked = false,
     this.scrollController,
+    this.clickableArea,
   }) : super(key: key);
 
   @override
@@ -148,6 +149,9 @@ class JustTheTooltip extends StatefulWidget implements JustTheInterface {
 
   @override
   final ScrollController? scrollController;
+
+  @override
+  final Rect? clickableArea;
 
   @override
   JustTheTooltipState<OverlayEntry> createState() =>
@@ -524,6 +528,11 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
 
   void _handlePointerEvent(PointerEvent event) {
     if (!hasEntry) {
+      return;
+    }
+
+    if (widget.clickableArea != null &&
+        widget.clickableArea!.contains(event.position)) {
       return;
     }
 

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -12,6 +12,7 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
     required this.child,
     this.onDismiss,
     this.onShow,
+    this.onClick,
     this.controller,
     this.isModal = false,
     this.waitDuration,
@@ -56,6 +57,9 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
 
   @override
   final VoidCallback? onShow;
+
+  @override
+  final VoidCallback? onClick;
 
   @override
   final bool isModal;

--- a/lib/src/just_the_tooltip_entry.dart
+++ b/lib/src/just_the_tooltip_entry.dart
@@ -39,6 +39,7 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
     this.shadow,
     this.showWhenUnlinked = false,
     this.scrollController,
+    this.clickableArea,
   });
 
   @override
@@ -130,6 +131,9 @@ class JustTheTooltipEntry extends StatefulWidget implements JustTheInterface {
 
   @override
   final ScrollController? scrollController;
+
+  @override
+  final Rect? clickableArea;
 
   @override
   JustTheTooltipState<Widget> createState() => _JustTheTooltipEntryState();

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -226,4 +226,8 @@ abstract class JustTheInterface extends StatefulWidget {
   /// example, if the tooltip happens to go beyond its quadrant but there is
   /// scroll space beneath it the bounds will accomadate it.
   ScrollController? get scrollController;
+
+  /// If passed, the given area on screen will be allowed to click through without
+  /// dismissing the tooltip in non-modal mode
+  Rect? get clickableArea;
 }

--- a/lib/src/models/just_the_interface.dart
+++ b/lib/src/models/just_the_interface.dart
@@ -102,6 +102,9 @@ abstract class JustTheInterface extends StatefulWidget {
   /// Called when the tooltip is shown.
   VoidCallback? get onShow;
 
+  /// Called when clicking on the tooltip
+  VoidCallback? get onClick;
+
   /// If true, once the tooltip is opened, it will not close after a set
   /// duration. It will instead instead stay on the screen until either the
   /// `scrim` is clicked or it is forcibly closed


### PR DESCRIPTION
`clickableArea` defines an area on screen that is allow to click through without dismissing the tooltip in non-modal mode.