### PR TITLE
Add navigator as ancestor to Offset

### DIFF
--- a/lib/src/just_the_tooltip.dart
+++ b/lib/src/just_the_tooltip.dart
@@ -748,9 +748,13 @@ abstract class JustTheTooltipState<T> extends State<JustTheInterface>
         'Cannot find the box for the given object with context $context',
       );
     }
-
+    
+    final navigator = Navigator.of(context);
     final targetSize = box.getDryLayout(const BoxConstraints.tightForFinite());
-    final target = box.localToGlobal(box.size.center(Offset.zero));
+    final target = box.localToGlobal(
+      box.size.center(Offset.zero),
+      ancestor: navigator.context.findRenderObject(),
+    );
     // TODO: Instead of this, change the alignment on
     // [CompositedTransformFollower]. That way we can allow a user configurable
     // alignment on where the tooltip ends up.


### PR DESCRIPTION
Add `navigator.context.findRenderObject()` as an ancestor to position the overlay offset. This is required to work correctly inside a RouterOutlet. Flutter overlay widgets implements this, for example DropdownButton.